### PR TITLE
Fix import collision error in test file

### DIFF
--- a/cpp_compliance_test.go
+++ b/cpp_compliance_test.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/bytearena/box2d"
+	"github.com/ByteArena/box2d"
 	"github.com/pmezard/go-difflib/difflib"
 )
 


### PR DESCRIPTION
It's happen when run fetch library with `go get` subcommand

```
$ go test -v ./...
cpp_compliance_test.go:9:2: case-insensitive import collision: "github.com/bytearena/box2d" and "github.com/ByteArena/box2d"
FAIL	github.com/ByteArena/box2d [setup failed]
```

because github username use `ByteArena` not `bytearena`