### PR TITLE
Changed parameter *B2JointDef to B2JointDefInterface

### DIFF
--- a/DynamicsB2Joint.go
+++ b/DynamicsB2Joint.go
@@ -197,7 +197,7 @@ func (j B2Joint) GetNext() B2JointInterface { // returns pointer
 
 //@goadd
 func (j *B2Joint) SetNext(next B2JointInterface) { // has to be backed by pointer
-	j.SetNext(next)
+	j.M_next = next
 }
 
 func (j B2Joint) GetPrev() B2JointInterface { // returns pointer
@@ -377,11 +377,13 @@ func MakeB2Joint(def B2JointDefInterface) *B2Joint { // def has to be backed by 
 	res.M_islandFlag = false
 	res.M_userData = def.GetUserData()
 
+	res.M_edgeA = &B2JointEdge{}
 	res.M_edgeA.Joint = nil
 	res.M_edgeA.Other = nil
 	res.M_edgeA.Prev = nil
 	res.M_edgeA.Next = nil
 
+	res.M_edgeB = &B2JointEdge{}
 	res.M_edgeB.Joint = nil
 	res.M_edgeB.Other = nil
 	res.M_edgeB.Prev = nil

--- a/DynamicsB2World.go
+++ b/DynamicsB2World.go
@@ -275,7 +275,8 @@ func (world *B2World) DestroyBody(b *B2Body) {
 	world.M_bodyCount--
 }
 
-func (world *B2World) CreateJoint(def *B2JointDef) B2JointInterface {
+// parameter 'def' should be pointer to joint def type.(*B2PrismaticJointDef, for example)
+func (world *B2World) CreateJoint(def B2JointDefInterface) B2JointInterface {
 	B2Assert(world.IsLocked() == false)
 	if world.IsLocked() {
 		return nil
@@ -312,11 +313,11 @@ func (world *B2World) CreateJoint(def *B2JointDef) B2JointInterface {
 	}
 	j.GetBodyB().M_jointList = j.GetEdgeB()
 
-	bodyA := def.BodyA
-	bodyB := def.BodyB
+	bodyA := def.GetBodyA()
+	bodyB := def.GetBodyB()
 
 	// If the joint prevents collisions, then flag any contacts for filtering.
-	if def.CollideConnected == false {
+	if def.IsCollideConnected() == false {
 		edge := bodyB.GetContactList()
 		for edge != nil {
 			if edge.Other == bodyA {

--- a/DynamicsB2World.go
+++ b/DynamicsB2World.go
@@ -1274,7 +1274,7 @@ func (world *B2World) Dump() {
 	fmt.Print("m_world.SetGravity(g);\n")
 
 	fmt.Print(fmt.Printf("b2Body** bodies = (b2Body**)b2Alloc(%d * sizeof(b2Body*));\n", world.M_bodyCount))
-	//fmt.Print("b2Joint** joints = (b2Joint**)b2Alloc(%d * sizeof(b2Joint*));\n", m_jointCount)
+	fmt.Print(fmt.Printf("b2Joint** joints = (b2Joint**)b2Alloc(%d * sizeof(b2Joint*));\n", world.M_jointCount))
 	i := 0
 	for b := world.M_bodyList; b != nil; b = b.M_next {
 		b.M_islandIndex = i


### PR DESCRIPTION
Uhm... I think it should be like this.

`CreateJoint` accepts only `*B2JointDef` and passes it to `B2JointCreate`.
`B2JointCreate` method will do type assertion and this assertion will be failed because type of passed value is `*B2JointDef` even if I pass `&b2prismaticjointdef.B2JointDef`.