### PR TITLE
Replace wrong variable in Solve

### DIFF
--- a/CommonB2Math.go
+++ b/CommonB2Math.go
@@ -310,7 +310,7 @@ func (m B2Mat22) Solve(b B2Vec2) B2Vec2 {
 
 	return MakeB2Vec2(
 		det*(a22*b.X-a12*b.Y),
-		det*(a11*b.Y-a21*b.Y),
+		det*(a11*b.Y-a21*b.X),
 	)
 }
 


### PR DESCRIPTION
This is the original Box2D code:
```
b2Vec2 x;
x.x = det * (a22 * b.x - a12 * b.y);
x.y = det * (a11 * b.y - a21 * b.x);
return x;
```