### PR TITLE
Fix to make contact filters work by default

### DIFF
--- a/DynamicsB2ContactManager.go
+++ b/DynamicsB2ContactManager.go
@@ -8,7 +8,7 @@ type B2ContactManager struct {
 	M_contactListener B2ContactListenerInterface
 }
 
-var b2_defaultFilter B2ContactFilterInterface
+var b2_defaultFilter = &B2ContactFilter{}
 var b2_defaultListener B2ContactListenerInterface
 
 func MakeB2ContactManager() B2ContactManager {


### PR DESCRIPTION
Using `SetFilterData` on a fixture doesn't have an effet currently because of a nil check on `B2ContactManager.M_contactFilter` which is nil by default.

Setting `b2_defaultFilter` to default data solves that issue and makes contact filtering work as expected.