### PR TITLE
Added the default Filter for MakeB2FixtureDef to fix the collision issue

### DIFF
--- a/DynamicsB2Fixture.go
+++ b/DynamicsB2Fixture.go
@@ -64,6 +64,7 @@ func MakeB2FixtureDef() B2FixtureDef {
 		Restitution: 0.0,
 		Density:     0.0,
 		IsSensor:    false,
+		Filter:      B2Filter{CategoryBits: 0x0001,MaskBits:0xFFFF},
 	}
 }
 


### PR DESCRIPTION
Issue reported https://github.com/ByteArena/box2d/issues/28

The problem wasn't initially noticeable, but became apparent after commit a6df559053ea43d68d08d97682d86114bca6b7f0 for anything where collision Filter isn't explicitly set. The problem is that the function that makes the fixture doesn't assign a default collision filter which results in category/mask being set to 0, disabling collision. The Box2D documentation indicates the default should be 0x0001 and 0xFFFF respectively.